### PR TITLE
Postings Object Implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "clangd.path": "/usr/bin/clangd",
     "C_Cpp.codeAnalysis.runAutomatically": true,
     "editor.formatOnSave": false,
-    "C_Cpp.intelliSenseEngine": "disabled",
+    "C_Cpp.intelliSenseEngine": "default",
     "C_Cpp.codeAnalysis.clangTidy.enabled": true,
     "C_Cpp.codeAnalysis.clangTidy.useBuildPath": true,
     "clangd.arguments": [
@@ -17,5 +17,8 @@
         "--query-driver=**"
     ],
     "clangd.inactiveRegions.useBackgroundHighlight": true,
-    "clangd.enableCodeCompletion": true
+    "clangd.enableCodeCompletion": true,
+    "files.associations": {
+        "string_view": "cpp"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,4 @@
     ],
     "clangd.inactiveRegions.useBackgroundHighlight": true,
     "clangd.enableCodeCompletion": true,
-    "files.associations": {
-        "string_view": "cpp"
-    }
 }

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -1,0 +1,169 @@
+#include "src/indexes/text/posting.h"
+
+#include <algorithm>
+#include <map>
+#include <vector>
+#include <cassert>
+#include <stdexcept>
+#include <type_traits>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/string_view.h"
+
+namespace valkey_search::text {
+
+// Factory method to create optimal field mask based on field count
+std::unique_ptr<FieldMask> FieldMask::Create(size_t num_fields) {
+  if (num_fields == 0) {
+    throw std::invalid_argument("num_fields must be greater than 0");
+  }
+  
+  // Select most memory-efficient implementation
+  if (num_fields <= 1) {
+    return std::make_unique<SingleFieldMask>();  // bool (1 byte)
+  } else if (num_fields <= 8) {
+    return std::make_unique<ByteFieldMask>(num_fields);  // uint8_t (1 byte)
+  } else if (num_fields <= 64) {
+    return std::make_unique<Uint64FieldMask>(num_fields);  // uint64_t (8 bytes)
+  } else {
+    throw std::invalid_argument("Too many text fields (max 64 supported)");
+  }
+}
+
+// Template implementation - uses compile-time branching for optimal performance
+template<typename MaskType, size_t MAX_FIELDS>
+FieldMaskImpl<MaskType, MAX_FIELDS>::FieldMaskImpl(size_t num_fields) 
+    : mask_(MaskType{}), num_fields_(num_fields) {
+  if (num_fields > MAX_FIELDS) {
+    throw std::invalid_argument("Field count exceeds maximum for this mask type");
+  }
+}
+
+template<typename MaskType, size_t MAX_FIELDS>
+void FieldMaskImpl<MaskType, MAX_FIELDS>::SetField(size_t field_index) {
+  if (field_index >= num_fields_) {
+    throw std::out_of_range("Field index out of range");
+  }
+  
+  // Compile-time branching: bool vs bitwise operations
+  if constexpr (std::is_same_v<MaskType, bool>) {
+    mask_ = true;  // Single field case
+  } else {
+    mask_ |= (MaskType(1) << field_index);  // Set bit at field_index
+  }
+}
+
+template<typename MaskType, size_t MAX_FIELDS>
+void FieldMaskImpl<MaskType, MAX_FIELDS>::ClearField(size_t field_index) {
+  if (field_index >= num_fields_) {
+    throw std::out_of_range("Field index out of range");
+  }
+  
+  if constexpr (std::is_same_v<MaskType, bool>) {
+    mask_ = false;  // Single field case
+  } else {
+    mask_ &= ~(MaskType(1) << field_index);  // Clear bit at field_index
+  }
+}
+
+template<typename MaskType, size_t MAX_FIELDS>
+bool FieldMaskImpl<MaskType, MAX_FIELDS>::HasField(size_t field_index) const {
+  if (field_index >= num_fields_) {
+    return false;
+  }
+  
+  if constexpr (std::is_same_v<MaskType, bool>) {
+    return mask_;  // Single field case
+  } else {
+    return (mask_ & (MaskType(1) << field_index)) != 0;  // Test bit at field_index
+  }
+}
+
+template<typename MaskType, size_t MAX_FIELDS>
+void FieldMaskImpl<MaskType, MAX_FIELDS>::SetAllFields() {
+  if constexpr (std::is_same_v<MaskType, bool>) {
+    mask_ = true;
+  } else {
+    if (num_fields_ == MAX_FIELDS && MAX_FIELDS == 64) {
+      mask_ = ~MaskType(0);  // Special case: avoid undefined behavior for 64-bit shift
+    } else {
+      mask_ = (MaskType(1) << num_fields_) - 1;  // Set num_fields_ bits
+    }
+  }
+}
+
+template<typename MaskType, size_t MAX_FIELDS>
+void FieldMaskImpl<MaskType, MAX_FIELDS>::ClearAllFields() {
+  mask_ = MaskType{};  // Zero-initialize
+}
+
+template<typename MaskType, size_t MAX_FIELDS>
+uint64_t FieldMaskImpl<MaskType, MAX_FIELDS>::AsUint64() const {
+  if constexpr (std::is_same_v<MaskType, bool>) {
+    return mask_ ? 1ULL : 0ULL;  // Convert bool to 0/1
+  } else {
+    return static_cast<uint64_t>(mask_);  // Cast integer types to uint64_t
+  }
+}
+
+template<typename MaskType, size_t MAX_FIELDS>
+std::unique_ptr<FieldMask> FieldMaskImpl<MaskType, MAX_FIELDS>::Clone() const {
+  auto clone = std::make_unique<FieldMaskImpl<MaskType, MAX_FIELDS>>(num_fields_);
+  clone->mask_ = mask_;
+  return clone;
+}
+
+// Explicit template instantiations
+template class FieldMaskImpl<bool, 1>;
+template class FieldMaskImpl<uint8_t, 8>;
+template class FieldMaskImpl<uint64_t, 64>;
+
+
+
+// TODO : Posting Implementation 
+// Posting entry structure - combines position with field mask
+struct PostingEntry {
+  Position position;
+  uint64_t field_mask;  // Uses FieldMask::AsUint64() for storage
+  
+  PostingEntry(Position pos, uint64_t mask) 
+      : position(pos), field_mask(mask) {}
+      
+  bool operator<(const PostingEntry& other) const {
+    return position < other.position;
+  }
+};
+
+class Postings::Impl {
+public:
+  bool save_positions_;
+  size_t num_text_fields_;
+  std::map<Key, std::vector<PostingEntry>> key_to_positions_;
+  
+  Impl(bool save_positions, size_t num_text_fields)
+      : save_positions_(save_positions), num_text_fields_(num_text_fields) {}
+};
+
+Postings::Postings(bool save_positions, size_t num_text_fields) 
+    : impl_(std::make_unique<Impl>(save_positions, num_text_fields)) {
+}
+
+Postings::~Postings() = default;
+
+Postings::Postings(const Postings& other) 
+    : impl_(std::make_unique<Impl>(*other.impl_)) {}
+
+Postings& Postings::operator=(const Postings& other) {
+  if (this != &other) {
+    impl_ = std::make_unique<Impl>(*other.impl_);
+  }
+  return *this;
+}
+
+bool Postings::IsEmpty() const { return true; }
+void Postings::SetKey(const Key&, std::span<Position>) {}
+void Postings::RemoveKey(const Key&) {}
+size_t Postings::GetKeyCount() const { return 0; }
+size_t Postings::GetPostingCount() const { return 0; }
+Postings* Postings::Defrag() { return this; }
+}

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -1,17 +1,22 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
 #include "src/indexes/text/posting.h"
 
-#include <algorithm>
+#include <cstdint>
 #include <map>
-#include <vector>
-#include <cassert>
+#include <memory>
 #include <stdexcept>
 #include <type_traits>
 
-#include "absl/container/flat_hash_map.h"
-#include "absl/strings/string_view.h"
-
 namespace valkey_search::text {
 
+// Field Mask Implementation
+  
 // Factory method to create optimal field mask based on field count
 std::unique_ptr<FieldMask> FieldMask::Create(size_t num_fields) {
   if (num_fields == 0) {
@@ -30,7 +35,7 @@ std::unique_ptr<FieldMask> FieldMask::Create(size_t num_fields) {
   }
 }
 
-// Template implementation - uses compile-time branching for optimal performance
+// Initialize field mask with specified field count
 template<typename MaskType, size_t MAX_FIELDS>
 FieldMaskImpl<MaskType, MAX_FIELDS>::FieldMaskImpl(size_t num_fields) 
     : mask_(MaskType{}), num_fields_(num_fields) {
@@ -39,20 +44,21 @@ FieldMaskImpl<MaskType, MAX_FIELDS>::FieldMaskImpl(size_t num_fields)
   }
 }
 
+// Set a specific field bit to true
 template<typename MaskType, size_t MAX_FIELDS>
 void FieldMaskImpl<MaskType, MAX_FIELDS>::SetField(size_t field_index) {
   if (field_index >= num_fields_) {
     throw std::out_of_range("Field index out of range");
   }
   
-  // Compile-time branching: bool vs bitwise operations
   if constexpr (std::is_same_v<MaskType, bool>) {
-    mask_ = true;  // Single field case
+    mask_ = true;
   } else {
-    mask_ |= (MaskType(1) << field_index);  // Set bit at field_index
+    mask_ |= (MaskType(1) << field_index);
   }
 }
 
+// Clear a specific field bit
 template<typename MaskType, size_t MAX_FIELDS>
 void FieldMaskImpl<MaskType, MAX_FIELDS>::ClearField(size_t field_index) {
   if (field_index >= num_fields_) {
@@ -60,12 +66,13 @@ void FieldMaskImpl<MaskType, MAX_FIELDS>::ClearField(size_t field_index) {
   }
   
   if constexpr (std::is_same_v<MaskType, bool>) {
-    mask_ = false;  // Single field case
+    mask_ = false;
   } else {
-    mask_ &= ~(MaskType(1) << field_index);  // Clear bit at field_index
+    mask_ &= ~(MaskType(1) << field_index);
   }
 }
 
+// Check if a specific field bit is set
 template<typename MaskType, size_t MAX_FIELDS>
 bool FieldMaskImpl<MaskType, MAX_FIELDS>::HasField(size_t field_index) const {
   if (field_index >= num_fields_) {
@@ -73,12 +80,13 @@ bool FieldMaskImpl<MaskType, MAX_FIELDS>::HasField(size_t field_index) const {
   }
   
   if constexpr (std::is_same_v<MaskType, bool>) {
-    return mask_;  // Single field case
+    return mask_;
   } else {
-    return (mask_ & (MaskType(1) << field_index)) != 0;  // Test bit at field_index
+    return (mask_ & (MaskType(1) << field_index)) != 0;
   }
 }
 
+// Set all field bits to true
 template<typename MaskType, size_t MAX_FIELDS>
 void FieldMaskImpl<MaskType, MAX_FIELDS>::SetAllFields() {
   if constexpr (std::is_same_v<MaskType, bool>) {
@@ -92,11 +100,27 @@ void FieldMaskImpl<MaskType, MAX_FIELDS>::SetAllFields() {
   }
 }
 
+// Clear all field bits
 template<typename MaskType, size_t MAX_FIELDS>
 void FieldMaskImpl<MaskType, MAX_FIELDS>::ClearAllFields() {
   mask_ = MaskType{};  // Zero-initialize
 }
 
+// Count number of set field bits
+template<typename MaskType, size_t MAX_FIELDS>
+size_t FieldMaskImpl<MaskType, MAX_FIELDS>::CountSetFields() const {
+  if constexpr (std::is_same_v<MaskType, bool>) {
+    return mask_ ? 1 : 0;  // Single field case: either 0 or 1
+  } else if constexpr (std::is_same_v<MaskType, uint8_t>) {
+    return __builtin_popcount(static_cast<unsigned int>(mask_));  // Count bits in uint8_t
+  } else if constexpr (std::is_same_v<MaskType, uint64_t>) {
+    return __builtin_popcountll(mask_);  // Count bits in uint64_t
+  } else {
+    throw std::invalid_argument("Unsupported mask type for CountSetFields");
+  }
+}
+
+// Convert field mask to standard uint64_t representation
 template<typename MaskType, size_t MAX_FIELDS>
 uint64_t FieldMaskImpl<MaskType, MAX_FIELDS>::AsUint64() const {
   if constexpr (std::is_same_v<MaskType, bool>) {
@@ -106,6 +130,7 @@ uint64_t FieldMaskImpl<MaskType, MAX_FIELDS>::AsUint64() const {
   }
 }
 
+// Create deep copy of field mask
 template<typename MaskType, size_t MAX_FIELDS>
 std::unique_ptr<FieldMask> FieldMaskImpl<MaskType, MAX_FIELDS>::Clone() const {
   auto clone = std::make_unique<FieldMaskImpl<MaskType, MAX_FIELDS>>(num_fields_);
@@ -118,41 +143,61 @@ template class FieldMaskImpl<bool, 1>;
 template class FieldMaskImpl<uint8_t, 8>;
 template class FieldMaskImpl<uint64_t, 64>;
 
+// Basic Postings Object Implementation
 
-
-// TODO : Posting Implementation 
-// Posting entry structure - combines position with field mask
-struct PostingEntry {
-  Position position;
-  uint64_t field_mask;  // Uses FieldMask::AsUint64() for storage
-  
-  PostingEntry(Position pos, uint64_t mask) 
-      : position(pos), field_mask(mask) {}
-      
-  bool operator<(const PostingEntry& other) const {
-    return position < other.position;
-  }
-};
+// Position map type alias - maps position to optimized FieldMask objects
+using PositionMap = std::map<Position, std::unique_ptr<FieldMask>>;
 
 class Postings::Impl {
 public:
   bool save_positions_;
   size_t num_text_fields_;
-  std::map<Key, std::vector<PostingEntry>> key_to_positions_;
+  std::map<Key, PositionMap> key_to_positions_;
   
   Impl(bool save_positions, size_t num_text_fields)
       : save_positions_(save_positions), num_text_fields_(num_text_fields) {}
+  
+  Impl(const Impl& other) 
+      : save_positions_(other.save_positions_), num_text_fields_(other.num_text_fields_) {
+    for (const auto& [key, pos_map] : other.key_to_positions_) {
+      PositionMap cloned_pos_map;
+      for (const auto& [pos, field_mask] : pos_map) {
+        cloned_pos_map[pos] = field_mask->Clone();
+      }
+      key_to_positions_[key] = std::move(cloned_pos_map);
+    }
+  }
+  
+  Impl& operator=(const Impl& other) {
+    if (this != &other) {
+      save_positions_ = other.save_positions_;
+      num_text_fields_ = other.num_text_fields_;
+      key_to_positions_.clear();
+      
+      for (const auto& [key, pos_map] : other.key_to_positions_) {
+        PositionMap cloned_pos_map;
+        for (const auto& [pos, field_mask] : pos_map) {
+          cloned_pos_map[pos] = field_mask->Clone();
+        }
+        key_to_positions_[key] = std::move(cloned_pos_map);
+      }
+    }
+    return *this;
+  }
 };
 
 Postings::Postings(bool save_positions, size_t num_text_fields) 
     : impl_(std::make_unique<Impl>(save_positions, num_text_fields)) {
 }
 
+// Automatic cleanup via unique_ptr
 Postings::~Postings() = default;
 
+// Deep copy of all posting data
 Postings::Postings(const Postings& other) 
     : impl_(std::make_unique<Impl>(*other.impl_)) {}
 
+// Safe replacement with deep copy
 Postings& Postings::operator=(const Postings& other) {
   if (this != &other) {
     impl_ = std::make_unique<Impl>(*other.impl_);
@@ -160,10 +205,208 @@ Postings& Postings::operator=(const Postings& other) {
   return *this;
 }
 
-bool Postings::IsEmpty() const { return true; }
-void Postings::SetKey(const Key&, std::span<Position>) {}
-void Postings::RemoveKey(const Key&) {}
-size_t Postings::GetKeyCount() const { return 0; }
-size_t Postings::GetPostingCount() const { return 0; }
-Postings* Postings::Defrag() { return this; }
+// Check if posting list contains any documents
+bool Postings::IsEmpty() const {
+  return impl_->key_to_positions_.empty();
+}
+
+// Add document key for boolean search (no position tracking)
+void Postings::SetKey(const Key& key) {
+  // This function is designed for boolean search (save_positions=false mode)
+  if (impl_->save_positions_) {
+    throw std::invalid_argument("SetKey() is only for boolean search mode (save_positions=false). Use AddPositionForField() instead.");
+  }
+  
+  // Just record document presence with assumed position 0 and empty field mask
+  auto& pos_map = impl_->key_to_positions_[key];
+  pos_map.clear();
+  
+  // Store single dummy position with empty field mask - now creates actual FieldMask object!
+  pos_map[0] = FieldMask::Create(impl_->num_text_fields_);  // Position 0, no fields set
+}
+
+// Add term occurrence at specific position and field
+void Postings::AddPositionForField(const Key& key, Position position, size_t field_index) {
+  if (field_index >= impl_->num_text_fields_) {
+    throw std::out_of_range("Field index out of range");
+  }
+  
+  auto& pos_map = impl_->key_to_positions_[key];
+  
+  // Check if position already exists
+  auto it = pos_map.find(position);
+  
+  if (it != pos_map.end()) {
+    // Position exists - directly add field to existing FieldMask object (much cleaner!)
+    it->second->SetField(field_index);
+  } else {
+    // New position - create entry with only this field
+    auto field_mask = FieldMask::Create(impl_->num_text_fields_);
+    field_mask->SetField(field_index);
+    pos_map[position] = std::move(field_mask);
+  }
+}
+
+// Replace all positions for a key with new position/field pairs
+void Postings::SetKeyWithFieldPositions(const Key& key, std::span<std::pair<Position, size_t>> position_field_pairs) {
+  auto& pos_map = impl_->key_to_positions_[key];
+  pos_map.clear();  // Replace existing positions
+  
+  // Group positions by position value
+  std::map<Position, std::unique_ptr<FieldMask>> position_masks;
+  
+  for (const auto& [pos, field_idx] : position_field_pairs) {
+    if (field_idx >= impl_->num_text_fields_) {
+      throw std::out_of_range("Field index out of range");
+    }
+    
+    if (position_masks.find(pos) == position_masks.end()) {
+      position_masks[pos] = FieldMask::Create(impl_->num_text_fields_);
+    }
+    position_masks[pos]->SetField(field_idx);
+  }
+  
+  // Move FieldMask objects to PositionMap (automatically maintains sorted order)
+  for (auto& [pos, mask] : position_masks) {
+    pos_map[pos] = std::move(mask);
+  }
+}
+
+// Merge new position/field pairs with existing positions for a key
+void Postings::UpdateKeyWithFieldPositions(const Key& key, std::span<std::pair<Position, size_t>> position_field_pairs) {
+  auto& pos_map = impl_->key_to_positions_[key];
+  // NO pos_map.clear() - preserve existing positions!
+  
+  for (const auto& [pos, field_idx] : position_field_pairs) {
+    if (field_idx >= impl_->num_text_fields_) {
+      throw std::out_of_range("Field index out of range");
+    }
+    
+    // Check if position already exists
+    auto it = pos_map.find(pos);
+    
+    if (it != pos_map.end()) {
+      // Position exists - add field to existing FieldMask
+      it->second->SetField(field_idx);
+    } else {
+      // New position - create entry with only this field
+      auto field_mask = FieldMask::Create(impl_->num_text_fields_);
+      field_mask->SetField(field_idx);
+      pos_map[pos] = std::move(field_mask);
+    }
+  }
+}
+
+// Remove a document key and all its positions
+void Postings::RemoveKey(const Key& key) {
+  impl_->key_to_positions_.erase(key);
+}
+
+// Get total number of document keys
+size_t Postings::GetKeyCount() const {
+  return impl_->key_to_positions_.size();
+}
+
+// Get total number of position entries across all keys
+size_t Postings::GetPostingCount() const {
+  size_t total = 0;
+  for (const auto& [key, positions] : impl_->key_to_positions_) {
+    total += positions.size();
+  }
+  return total;
+}
+
+// Get total term frequency (sum of field occurrences across all positions)
+size_t Postings::GetTotalTermFrequency() const {
+  size_t total_frequency = 0;
+  for (const auto& [key, positions] : impl_->key_to_positions_) {
+    for (const auto& [position, field_mask] : positions) {
+      // Use efficient bit manipulation to count set fields (much faster!)
+      total_frequency += field_mask->CountSetFields();
+    }
+  }
+  return total_frequency;
+}
+
+// Defragment posting list
+Postings* Postings::Defrag() {
+  return this;
+}
+
+// Iterators Implementation
+
+// Placeholder for GetKeyIterator - will be implemented when iterators are added
+Postings::KeyIterator Postings::GetKeyIterator() const {
+  // TODO: Implement when KeyIterator is added
+  static KeyIterator dummy;
+  return dummy;
+}
+
+// Placeholder implementations for KeyIterator
+bool Postings::KeyIterator::IsValid() const {
+  // TODO: Implement when KeyIterator is added
+  return false;
+}
+
+void Postings::KeyIterator::NextKey() {
+  // TODO: Implement when KeyIterator is added
+}
+
+bool Postings::KeyIterator::SkipForwardKey(const Key& key) {
+  // TODO: Implement when KeyIterator is added
+  return false;
+}
+
+const Key& Postings::KeyIterator::GetKey() const {
+  // TODO: Implement when KeyIterator is added
+  static Key dummy_key;
+  return dummy_key;
+}
+
+Postings::PositionIterator Postings::KeyIterator::GetPositionIterator() const {
+  // TODO: Implement when KeyIterator is added
+  static PositionIterator dummy;
+  return dummy;
+}
+
+// Placeholder implementations for PositionIterator
+bool Postings::PositionIterator::IsValid() const {
+  // TODO: Implement when PositionIterator is added
+  return false;
+}
+
+void Postings::PositionIterator::NextPosition() {
+  // TODO: Implement when PositionIterator is added
+}
+
+bool Postings::PositionIterator::SkipForwardPosition(const Position& position) {
+  // TODO: Implement when PositionIterator is added
+  return false;
+}
+
+const Position& Postings::PositionIterator::GetPosition() const {
+  // TODO: Implement when PositionIterator is added
+  static Position dummy_position = 0;
+  return dummy_position;
+}
+
+uint64_t Postings::PositionIterator::GetFieldMask() const {
+  // TODO: Implement when PositionIterator is added
+  return 0;
+}
+
+// Placeholder implementations for Posting struct
+const Key& Posting::GetKey() const {
+  static Key dummy_key;
+  return dummy_key;
+}
+
+uint64_t Posting::GetFieldMask() const {
+  return 0;
+}
+
+uint32_t Posting::GetPosition() const {
+  return 0;
+}
+
 }

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -364,6 +364,17 @@ target_link_libraries(vector_externalizer_test PUBLIC module)
 target_link_libraries(vector_externalizer_test PUBLIC valkey_module)
 finalize_test_flags(vector_externalizer_test)
 
+set(SRCS_POSTING_TEST ${CMAKE_CURRENT_LIST_DIR}/posting_test.cc
+                      ${CMAKE_SOURCE_DIR}/src/indexes/text/posting.cc)
+
+add_executable(posting_test ${SRCS_POSTING_TEST})
+target_include_directories(posting_test PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(posting_test PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(posting_test PUBLIC testing_common)
+target_link_libraries(posting_test PUBLIC string_interning)
+target_link_libraries(posting_test PUBLIC utils)
+finalize_test_flags(posting_test)
+
 set(SRCS_ACL_TEST ${CMAKE_CURRENT_LIST_DIR}/acl_test.cc)
 add_executable(acl_test ${SRCS_ACL_TEST})
 target_include_directories(acl_test PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/testing/posting_test.cc
+++ b/testing/posting_test.cc
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/text/posting.h"
+
+#include "gtest/gtest.h"
+
+namespace valkey_search::text {
+
+class PostingTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Create postings with different configurations for testing
+    boolean_postings_ = new Postings(false, 3);  // Boolean search, 3 fields
+    positional_postings_ = new Postings(true, 5); // Positional search, 5 fields
+  }
+  
+  void TearDown() override {
+    delete boolean_postings_;
+    delete positional_postings_;
+  }
+  
+  Postings* boolean_postings_;
+  Postings* positional_postings_;
+};
+
+// Test FieldMask factory and basic operations
+TEST_F(PostingTest, FieldMaskFactory) {
+  // Test single field mask
+  auto mask1 = FieldMask::Create(1);
+  EXPECT_EQ(mask1->MaxFields(), 1);
+  
+  // Test byte field mask
+  auto mask8 = FieldMask::Create(8);
+  EXPECT_EQ(mask8->MaxFields(), 8);
+  
+  // Test uint64 field mask
+  auto mask64 = FieldMask::Create(64);
+  EXPECT_EQ(mask64->MaxFields(), 64);
+  
+  // Test error cases
+  EXPECT_THROW(FieldMask::Create(0), std::invalid_argument);
+  EXPECT_THROW(FieldMask::Create(65), std::invalid_argument);
+}
+
+TEST_F(PostingTest, FieldMaskBasicOperations) {
+  auto mask = FieldMask::Create(5);
+  
+  // Initially no fields set
+  EXPECT_EQ(mask->CountSetFields(), 0);
+  EXPECT_FALSE(mask->HasField(0));
+  EXPECT_FALSE(mask->HasField(4));
+  
+  // Set some fields
+  mask->SetField(0);
+  mask->SetField(2);
+  mask->SetField(4);
+  
+  EXPECT_EQ(mask->CountSetFields(), 3);
+  EXPECT_TRUE(mask->HasField(0));
+  EXPECT_FALSE(mask->HasField(1));
+  EXPECT_TRUE(mask->HasField(2));
+  EXPECT_FALSE(mask->HasField(3));
+  EXPECT_TRUE(mask->HasField(4));
+  
+  // Clear a field
+  mask->ClearField(2);
+  EXPECT_EQ(mask->CountSetFields(), 2);
+  EXPECT_FALSE(mask->HasField(2));
+  
+  // Set all fields
+  mask->SetAllFields();
+  EXPECT_EQ(mask->CountSetFields(), 5);
+  for (size_t i = 0; i < 5; ++i) {
+    EXPECT_TRUE(mask->HasField(i));
+  }
+  
+  // Clear all fields
+  mask->ClearAllFields();
+  EXPECT_EQ(mask->CountSetFields(), 0);
+  for (size_t i = 0; i < 5; ++i) {
+    EXPECT_FALSE(mask->HasField(i));
+  }
+}
+
+TEST_F(PostingTest, FieldMaskClone) {
+  auto original = FieldMask::Create(3);
+  original->SetField(0);
+  original->SetField(2);
+  
+  auto clone = original->Clone();
+  EXPECT_EQ(clone->CountSetFields(), 2);
+  EXPECT_TRUE(clone->HasField(0));
+  EXPECT_FALSE(clone->HasField(1));
+  EXPECT_TRUE(clone->HasField(2));
+  
+  // Verify independence
+  original->SetField(1);
+  EXPECT_FALSE(clone->HasField(1));
+}
+
+TEST_F(PostingTest, PostingEmptyOperations) {
+  EXPECT_TRUE(boolean_postings_->IsEmpty());
+  EXPECT_EQ(boolean_postings_->GetKeyCount(), 0);
+  EXPECT_EQ(boolean_postings_->GetPostingCount(), 0);
+  EXPECT_EQ(boolean_postings_->GetTotalTermFrequency(), 0);
+}
+
+TEST_F(PostingTest, BooleanSearchSetKey) {
+  // Test valid boolean search mode
+  boolean_postings_->SetKey("doc1");
+  boolean_postings_->SetKey("doc2");
+  
+  EXPECT_FALSE(boolean_postings_->IsEmpty());
+  EXPECT_EQ(boolean_postings_->GetKeyCount(), 2);
+  EXPECT_EQ(boolean_postings_->GetPostingCount(), 2); // One position per key
+  
+  // Test error when using SetKey in positional mode
+  EXPECT_THROW(positional_postings_->SetKey("doc1"), std::invalid_argument);
+}
+
+TEST_F(PostingTest, AddPositionForField) {
+  // Add positions for different documents and fields
+  positional_postings_->AddPositionForField("doc1", 10, 0); // field 0, position 10
+  positional_postings_->AddPositionForField("doc1", 20, 1); // field 1, position 20
+  positional_postings_->AddPositionForField("doc1", 10, 2); // field 2, position 10 (same position, different field)
+  
+  EXPECT_EQ(positional_postings_->GetKeyCount(), 1);
+  EXPECT_EQ(positional_postings_->GetPostingCount(), 2); // Two unique positions (10, 20)
+  EXPECT_EQ(positional_postings_->GetTotalTermFrequency(), 3); // Three field occurrences total
+  
+  // Add second document
+  positional_postings_->AddPositionForField("doc2", 5, 0);
+  positional_postings_->AddPositionForField("doc2", 15, 0);
+  
+  EXPECT_EQ(positional_postings_->GetKeyCount(), 2);
+  EXPECT_EQ(positional_postings_->GetPostingCount(), 4); // Two positions per document
+  EXPECT_EQ(positional_postings_->GetTotalTermFrequency(), 5); // Five field occurrences total
+  
+  // Test field index bounds
+  EXPECT_THROW(positional_postings_->AddPositionForField("doc3", 1, 5), std::out_of_range);
+}
+
+TEST_F(PostingTest, SetKeyWithFieldPositions) {
+  // Test batch position setting (replace mode)
+  std::vector<std::pair<Position, size_t>> positions = {
+    {10, 0}, {10, 1}, {20, 2}, {30, 0}
+  };
+  
+  positional_postings_->SetKeyWithFieldPositions("doc1", positions);
+  
+  EXPECT_EQ(positional_postings_->GetKeyCount(), 1);
+  EXPECT_EQ(positional_postings_->GetPostingCount(), 3); // Three unique positions (10, 20, 30)
+  EXPECT_EQ(positional_postings_->GetTotalTermFrequency(), 4); // Four field occurrences
+  
+  // Test replace behavior - should clear previous positions
+  std::vector<std::pair<Position, size_t>> new_positions = {{5, 1}};
+  positional_postings_->SetKeyWithFieldPositions("doc1", positions);
+  positional_postings_->SetKeyWithFieldPositions("doc1", new_positions);
+  
+  EXPECT_EQ(positional_postings_->GetPostingCount(), 1); // Only one position remains
+  EXPECT_EQ(positional_postings_->GetTotalTermFrequency(), 1); // Only one field occurrence
+}
+
+TEST_F(PostingTest, UpdateKeyWithFieldPositions) {
+  // Set initial positions
+  std::vector<std::pair<Position, size_t>> initial_positions = {{10, 0}, {20, 1}};
+  positional_postings_->SetKeyWithFieldPositions("doc1", initial_positions);
+  
+  EXPECT_EQ(positional_postings_->GetPostingCount(), 2);
+  EXPECT_EQ(positional_postings_->GetTotalTermFrequency(), 2);
+  
+  // Update with additional positions (merge mode)
+  std::vector<std::pair<Position, size_t>> additional_positions = {{30, 2}, {10, 1}};
+  positional_postings_->UpdateKeyWithFieldPositions("doc1", additional_positions);
+  
+  EXPECT_EQ(positional_postings_->GetPostingCount(), 3); // Three unique positions (10, 20, 30)
+  EXPECT_EQ(positional_postings_->GetTotalTermFrequency(), 4); // position 10 now has 2 fields, others have 1 each
+}
+
+TEST_F(PostingTest, RemoveKey) {
+  // Add some data
+  positional_postings_->AddPositionForField("doc1", 10, 0);
+  positional_postings_->AddPositionForField("doc2", 20, 1);
+  
+  EXPECT_EQ(positional_postings_->GetKeyCount(), 2);
+  
+  // Remove one key
+  positional_postings_->RemoveKey("doc1");
+  EXPECT_EQ(positional_postings_->GetKeyCount(), 1);
+  EXPECT_EQ(positional_postings_->GetPostingCount(), 1);
+  
+  // Remove non-existent key (should be no-op)
+  positional_postings_->RemoveKey("nonexistent");
+  EXPECT_EQ(positional_postings_->GetKeyCount(), 1);
+  
+  // Remove last key
+  positional_postings_->RemoveKey("doc2");
+  EXPECT_TRUE(positional_postings_->IsEmpty());
+}
+
+TEST_F(PostingTest, CopyConstructorAndAssignment) {
+  // Set up original posting
+  positional_postings_->AddPositionForField("doc1", 10, 0);
+  positional_postings_->AddPositionForField("doc1", 20, 1);
+  
+  // Test copy constructor
+  Postings copy_constructed(*positional_postings_);
+  EXPECT_EQ(copy_constructed.GetKeyCount(), 1);
+  EXPECT_EQ(copy_constructed.GetPostingCount(), 2);
+  EXPECT_EQ(copy_constructed.GetTotalTermFrequency(), 2);
+  
+  // Test independence
+  positional_postings_->AddPositionForField("doc2", 30, 2);
+  EXPECT_EQ(copy_constructed.GetKeyCount(), 1); // Should not change
+  EXPECT_EQ(positional_postings_->GetKeyCount(), 2); // Original should change
+  
+  // Test copy assignment
+  Postings copy_assigned(false, 3);
+  copy_assigned = *positional_postings_;
+  EXPECT_EQ(copy_assigned.GetKeyCount(), 2);
+  EXPECT_EQ(copy_assigned.GetPostingCount(), 3);
+  
+  // Test self-assignment
+  copy_assigned = copy_assigned;
+  EXPECT_EQ(copy_assigned.GetKeyCount(), 2);
+}
+
+TEST_F(PostingTest, ErrorHandling) {
+  // Test field index validation
+  EXPECT_THROW(positional_postings_->AddPositionForField("doc1", 1, 5), std::out_of_range);
+  EXPECT_THROW(positional_postings_->AddPositionForField("doc1", 1, SIZE_MAX), std::out_of_range);
+  
+  // Test batch operations field validation
+  std::vector<std::pair<Position, size_t>> invalid_positions = {{10, 10}};
+  EXPECT_THROW(positional_postings_->SetKeyWithFieldPositions("doc1", invalid_positions), std::out_of_range);
+  EXPECT_THROW(positional_postings_->UpdateKeyWithFieldPositions("doc1", invalid_positions), std::out_of_range);
+  
+  // Test FieldMask bounds
+  auto mask = FieldMask::Create(3);
+  EXPECT_THROW(mask->SetField(3), std::out_of_range);
+  EXPECT_THROW(mask->ClearField(3), std::out_of_range);
+  EXPECT_FALSE(mask->HasField(3)); // Out of range should return false, not throw
+}
+
+TEST_F(PostingTest, LargeScaleOperations) {
+  // Test with many documents and positions
+  for (int doc = 0; doc < 100; ++doc) {
+    std::string key = "doc" + std::to_string(doc);
+    for (int pos = 0; pos < 10; ++pos) {
+      positional_postings_->AddPositionForField(key, pos * 10, pos % 5);
+    }
+  }
+  
+  EXPECT_EQ(positional_postings_->GetKeyCount(), 100);
+  EXPECT_EQ(positional_postings_->GetPostingCount(), 1000); // 100 docs * 10 positions each
+  EXPECT_EQ(positional_postings_->GetTotalTermFrequency(), 1000); // One field per position
+}
+
+}  // namespace valkey_search::text


### PR DESCRIPTION
## Field Mask Implementation

- Created an abstract `FieldMask` class with factory method for automatic selection
- Defined common interface: `SetField()`, `ClearField()`, `HasField()`, `SetAllFields()`, etc.
- Quantized Field Mask as below
  - `SingleFieldMask`: For 1 field - no storage overhead, just a boolean
  - `ByteFieldMask`: For 2-8 fields - uses `uint8_t` (1 byte storage)
  - `Uint64FieldMask`: For 9-64 fields - uses `uint64_t` (8 bytes storage)
- Automatically selects appropriate representation based on `num_text_fields`
