### PR TITLE
Implement text index per-component memory tracking (#655)

### DIFF
--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -1077,8 +1077,11 @@ void IndexSchema::RespondWithInfo(ValkeyModuleCtx *ctx) const {
   int arrSize = 28;
   // Text-attribute info fields
   if (text_index_schema_) {
-    arrSize += 8;  // punctuation, stop_words, with_offsets, min_stem_size (4
-                   // key-value pairs = 8 items)
+    arrSize += 8;   // punctuation, stop_words, with_offsets, min_stem_size (4
+                    // key-value pairs = 8 items)
+    arrSize += 8;   // text_postings_memory_bytes, text_position_memory_bytes,
+                    // text_rax_tree_memory_bytes, text_index_total_memory_bytes
+                    // (4 key-value pairs = 8 items)
   }
   ValkeyModule_ReplyWithArray(ctx, arrSize);
   ValkeyModule_ReplyWithSimpleString(ctx, "index_name");
@@ -1120,6 +1123,25 @@ void IndexSchema::RespondWithInfo(ValkeyModuleCtx *ctx) const {
   ValkeyModule_ReplyWithLongLong(
       ctx, text_index_schema_ ? text_index_schema_->GetNumUniqueTerms() : 0);
 
+  // Text index memory sub-component stats
+  if (text_index_schema_) {
+    ValkeyModule_ReplyWithSimpleString(ctx, "text_postings_memory_bytes");
+    ValkeyModule_ReplyWithLongLong(
+        ctx, static_cast<long long>(
+                 text_index_schema_->GetPostingsMemoryUsage()));
+    ValkeyModule_ReplyWithSimpleString(ctx, "text_position_memory_bytes");
+    ValkeyModule_ReplyWithLongLong(
+        ctx, static_cast<long long>(
+                 text_index_schema_->GetPositionMemoryUsage()));
+    ValkeyModule_ReplyWithSimpleString(ctx, "text_rax_tree_memory_bytes");
+    ValkeyModule_ReplyWithLongLong(
+        ctx, static_cast<long long>(
+                 text_index_schema_->GetRadixTreeMemoryUsage()));
+    ValkeyModule_ReplyWithSimpleString(ctx, "text_index_total_memory_bytes");
+    ValkeyModule_ReplyWithLongLong(
+        ctx, static_cast<long long>(
+                 text_index_schema_->GetTotalTextIndexMemoryUsage()));
+  }
   // Text Index info fields end
   ValkeyModule_ReplyWithSimpleString(ctx, "hash_indexing_failures");
   ValkeyModule_ReplyWithCString(

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -14,6 +14,7 @@
 #include "absl/log/check.h"
 #include "src/index_schema.h"
 #include "src/indexes/text/flat_position_map.h"
+#include "vmsdk/src/memory_tracker.h"
 
 namespace valkey_search::indexes::text {
 
@@ -61,7 +62,8 @@ void Postings::InsertKey(const Key& key, FlatPositionMap* flat_map) {
 }
 
 // Remove a document key and all its positions
-void Postings::RemoveKey(const Key& key, TextIndexMetadata* metadata) {
+void Postings::RemoveKey(const Key& key, TextIndexMetadata* metadata,
+                         MemoryPool* position_pool) {
   auto node = key_to_positions_.extract(key);
   if (node.empty()) return;
 
@@ -74,8 +76,15 @@ void Postings::RemoveKey(const Key& key, TextIndexMetadata* metadata) {
   metadata->total_positions -= position_count;
   metadata->total_term_frequency -= term_frequency;
 
-  // Destroy and remove from map
-  FlatPositionMap::Destroy(flat_map);
+  // Destroy position map, capturing the deallocation in position_pool when
+  // the caller provides one (same IsolatedMemoryScope pattern as
+  // StringInternStore::memory_pool_).
+  if (position_pool) {
+    IsolatedMemoryScope pos_scope(*position_pool);
+    FlatPositionMap::Destroy(flat_map);
+  } else {
+    FlatPositionMap::Destroy(flat_map);
+  }
 }
 
 // Get total number of document keys

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -81,8 +81,12 @@ struct Postings {
   // Insert the key with FlatPositionMap
   void InsertKey(const Key& key, FlatPositionMap* flat_map);
 
-  // Remove a key and all positions for it
-  void RemoveKey(const Key& key, TextIndexMetadata* metadata);
+  // Remove a key and all positions for it.
+  // If position_pool is non-null, the FlatPositionMap::Destroy call is wrapped
+  // in an IsolatedMemoryScope so the deallocation is captured in that pool
+  // separately from the postings-level bookkeeping the caller may be tracking.
+  void RemoveKey(const Key& key, TextIndexMetadata* metadata,
+                 MemoryPool* position_pool = nullptr);
 
   // Total number of keys
   size_t GetKeyCount() const;

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -16,6 +16,7 @@
 #include "libstemmer.h"
 #include "src/valkey_search_options.h"
 #include "vmsdk/src/memory_allocation.h"
+#include "vmsdk/src/memory_tracker.h"
 namespace valkey_search::indexes::text {
 
 namespace {
@@ -53,10 +54,10 @@ InvasivePtr<Postings> AddKeyToPostings(InvasivePtr<Postings> existing_postings,
 
 InvasivePtr<Postings> RemoveKeyFromPostings(
     InvasivePtr<Postings> existing_postings, const InternedStringPtr &key,
-    TextIndexMetadata *metadata) {
+    TextIndexMetadata *metadata, MemoryPool *position_pool = nullptr) {
   CHECK(existing_postings) << "Per-key tree became unaligned";
 
-  existing_postings->RemoveKey(key, metadata);
+  existing_postings->RemoveKey(key, metadata, position_pool);
 
   if (existing_postings->IsEmpty()) {
     metadata->num_unique_terms--;
@@ -229,9 +230,12 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
       metadata_.total_term_frequency += field_mask.CountSetFields();
     }
 
-    // Create FlatPositionMap from PositionMap
-    FlatPositionMap *flat_map =
-        FlatPositionMap::Create(pos_map, num_text_fields_);
+    // Create FlatPositionMap, capturing the allocation in position_memory_pool_.
+    FlatPositionMap *flat_map;
+    {
+      IsolatedMemoryScope pos_scope(metadata_.position_memory_pool_);
+      flat_map = FlatPositionMap::Create(pos_map, num_text_fields_);
+    }
 
     // The updated target gets set in target_add_fn and later used in
     // target_set_fn, so that all trees point to the same postings object
@@ -247,8 +251,13 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
       }
       bool is_new_word = !existing;
 
-      updated_target =
-          AddKeyToPostings(std::move(existing), key, flat_map, &metadata_);
+      // Capture Postings object allocation (InvasivePtr<Postings>::Make for new
+      // words) and the btree_map node inserted by InsertKey.
+      {
+        IsolatedMemoryScope postings_scope(metadata_.postings_memory_pool_);
+        updated_target =
+            AddKeyToPostings(std::move(existing), key, flat_map, &metadata_);
+      }
 
       if (is_new_word) {
         absl::WriterMutexLock tree_lock(&text_index_mutex_);
@@ -257,8 +266,11 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
       }
     }
 
-    // Update per-key index (no locking needed — local to this call).
-    key_index.MutateTarget(token, updated_target, reverse_token);
+    // Update per-key index, capturing rax node allocations in postings pool.
+    {
+      IsolatedMemoryScope key_rax_scope(metadata_.postings_memory_pool_);
+      key_index.MutateTarget(token, updated_target, reverse_token);
+    }
   }
 
   if (stem_text_field_mask_ && !stem_mappings.empty()) {
@@ -279,8 +291,10 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     }
   }
 
-  // Map the key to the newly created per-key index
+  // Map the key to the newly created per-key index, capturing the
+  // node_hash_map container node allocation in postings_memory_pool_.
   {
+    IsolatedMemoryScope emplace_scope(metadata_.postings_memory_pool_);
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     per_key_text_indexes_.emplace(key, std::move(key_index));
   }
@@ -317,9 +331,16 @@ void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
         existing = text_index_->GetPrefix().FindPostingsTarget(word_str);
       }
 
+      // Capture btree_map node deallocation (key_to_positions_.extract) and
+      // any InvasivePtr ref-count changes; FlatPositionMap::Destroy is
+      // captured separately inside RemoveKey via position_memory_pool_.
       InvasivePtr<Postings> updated_target;
-      updated_target =
-          RemoveKeyFromPostings(std::move(existing), key, &metadata_);
+      {
+        IsolatedMemoryScope postings_scope(metadata_.postings_memory_pool_);
+        updated_target = RemoveKeyFromPostings(std::move(existing), key,
+                                               &metadata_,
+                                               &metadata_.position_memory_pool_);
+      }
 
       if (!updated_target) {
         absl::WriterMutexLock tree_lock(&text_index_mutex_);
@@ -359,6 +380,16 @@ void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
       }
     }
   }
+
+  // Explicitly destroy the per-key TextIndex within a postings_memory_pool_
+  // scope so that the per-key rax node frees and ~Postings() destructor
+  // calls (for single-document words) are captured.
+  {
+    IsolatedMemoryScope per_key_cleanup(metadata_.postings_memory_pool_);
+    auto owned = std::move(node);
+    // owned destroyed here: per-key rax freed + FreePostingsCallback fires
+    // ~Postings() for any word whose last document was just removed.
+  }
 }
 
 uint64_t TextIndexSchema::GetTotalPositions() const {
@@ -371,6 +402,30 @@ uint64_t TextIndexSchema::GetNumUniqueTerms() const {
 
 uint64_t TextIndexSchema::GetTotalTermFrequency() const {
   return metadata_.total_term_frequency.load();
+}
+
+uint64_t TextIndexSchema::GetPostingsMemoryUsage() const {
+  return static_cast<uint64_t>(
+      std::max(int64_t{0}, metadata_.postings_memory_pool_.GetUsage()));
+}
+
+uint64_t TextIndexSchema::GetPositionMemoryUsage() const {
+  return static_cast<uint64_t>(
+      std::max(int64_t{0}, metadata_.position_memory_pool_.GetUsage()));
+}
+
+uint64_t TextIndexSchema::GetRadixTreeMemoryUsage() const {
+  uint64_t total = text_index_->GetPrefix().GetAllocSize();
+  auto suffix = text_index_->GetSuffix();
+  if (suffix.has_value()) {
+    total += suffix->get().GetAllocSize();
+  }
+  return total;
+}
+
+uint64_t TextIndexSchema::GetTotalTextIndexMemoryUsage() const {
+  return GetPostingsMemoryUsage() + GetPositionMemoryUsage() +
+         GetRadixTreeMemoryUsage();
 }
 
 std::string TextIndexSchema::GetAllStemVariants(

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -42,16 +42,23 @@ using TokenPositions =
 
 class TextIndexSchema;
 
-// FT.INFO counters for text info fields and memory pools
+// FT.INFO counters and per-component memory pools for the text index.
 struct TextIndexMetadata {
   std::atomic<uint64_t> total_positions{0};
   std::atomic<uint64_t> num_unique_terms{0};
   std::atomic<uint64_t> total_term_frequency{0};
 
-  // Memory pools for text index components
-  MemoryPool posting_memory_pool_{0};
-  MemoryPool radix_memory_pool_{0};
-  MemoryPool text_index_memory_pool_{0};
+  // Populated via IsolatedMemoryScope wrappers in CommitKeyData /
+  // DeleteKeyData (same mechanism as StringInternStore::memory_pool_).
+  //
+  // postings_memory_pool_: Postings objects, btree_map nodes inside each
+  //   Postings, per-key rax tree nodes, and per-key index container overhead.
+  // position_memory_pool_: FlatPositionMap allocations — one per document
+  //   per unique term.  Tracked separately by passing this pool into
+  //   Postings::RemoveKey so FlatPositionMap::Destroy is wrapped in its own
+  //   IsolatedMemoryScope.
+  MemoryPool postings_memory_pool_{0};
+  MemoryPool position_memory_pool_{0};
 };
 
 class TextIndex {
@@ -212,8 +219,13 @@ class TextIndexSchema {
   uint64_t GetTotalPositions() const;
   uint64_t GetNumUniqueTerms() const;
   uint64_t GetTotalTermFrequency() const;
-  // TODO: Implement the following APIs when we want granular memory metrics for
-  // text index components
+
+  // Per-component memory usage.
+  // GetPostingsMemoryUsage: Postings objects + btree nodes + per-key rax/nhm.
+  // GetPositionMemoryUsage: FlatPositionMap allocations.
+  // GetRadixTreeMemoryUsage: main prefix + optional suffix rax (via
+  //   Rax::GetAllocSize(), always exact, no runtime tracking needed).
+  // GetTotalTextIndexMemoryUsage: sum of the three components above.
   uint64_t GetPostingsMemoryUsage() const;
   uint64_t GetRadixTreeMemoryUsage() const;
   uint64_t GetPositionMemoryUsage() const;


### PR DESCRIPTION
Uses the same IsolatedMemoryScope / MemoryPool pattern as StringInternStore::memory_pool_ to automatically capture net bytes allocated/freed without manual size accounting.

Two pools are added to TextIndexMetadata:
- postings_memory_pool_: Postings objects, btree_map internal nodes, per-key rax tree nodes, and per-key node_hash_map container overhead.
- position_memory_pool_: FlatPositionMap allocations (one per document per unique term).

IsolatedMemoryScope wrappers are placed at:
  CommitKeyData:
    - FlatPositionMap::Create           → position_memory_pool_
    - AddKeyToPostings                  → postings_memory_pool_
    - key_index.MutateTarget (per-key)  → postings_memory_pool_
    - per_key_text_indexes_.emplace     → postings_memory_pool_
  DeleteKeyData:
    - RemoveKeyFromPostings             → postings_memory_pool_
      (FlatPositionMap::Destroy inside RemoveKey is wrapped in its own
       IsolatedMemoryScope via the new position_pool parameter so each
       FlatPositionMap free is credited to position_memory_pool_)
    - per-key TextIndex cleanup block   → postings_memory_pool_
      (captures per-key rax node frees and ~Postings() calls for
       words whose last document was just deleted)

Radix tree memory for the main prefix/suffix index is computed at query time via Rax::GetAllocSize() — always exact, no runtime tracking needed.

The four getter methods are now implemented:
  GetPostingsMemoryUsage()        → postings_memory_pool_.GetUsage()
  GetPositionMemoryUsage()        → position_memory_pool_.GetUsage()
  GetRadixTreeMemoryUsage()       → GetAllocSize() of prefix + suffix rax
  GetTotalTextIndexMemoryUsage()  → sum of all three

All four values are exposed in FT.INFO as:
  text_postings_memory_bytes, text_position_memory_bytes,
  text_rax_tree_memory_bytes, text_index_total_memory_bytes

Fixes #655