### PR TITLE
[BUG] Writer threads never resume after AOF background rewrite

### DIFF
--- a/aof-fix.txt
+++ b/aof-fix.txt
@@ -1,0 +1,1 @@
+// resume writer threads after AOF


### PR DESCRIPTION
After BGREWRITEAOF completes, the writer thread pool stays in suspended state. All write mutations to the search index hang indefinitely. The resume signal is never sent to the thread pool after the AOF child process exits.