### PR TITLE
Test #1130: PR targeting non-release branch (should SKIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,5 @@ For development purposes, it is recommended to use <b>VSCode</b>, which is alrea
 
        Once connected, VSCode will open the repository in the context of the remote host.
 
+
+# trigger ci (disallowed base)


### PR DESCRIPTION
Validates PR #1130 gate. Base branch `not-a-release-branch-1130` is NOT in .github/release-branches.txt, so the check-branch gate should output should_run=false and the test jobs should be SKIPPED (grey/neutral), NOT failed (red). Contrast with #1058's old behavior which failed red at the Verify Branch step.