### PR TITLE
Tests only: HNSW offsetData_ alignment regression tests (expected to FAIL without fix)

### DIFF
--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -34,6 +34,8 @@
 #include "src/utils/string_interning.h"
 #include "src/valkey_search_options.h"
 #include "testing/common.h"
+#include "third_party/hnswlib/index.pb.h"
+#include "third_party/hnswlib/iostream.h"
 #include "third_party/hnswlib/space_ip.h"
 #include "third_party/hnswlib/space_l2.h"
 #include "vmsdk/src/managed_pointers.h"
@@ -651,6 +653,73 @@ ABSL_NO_THREAD_SAFETY_ANALYSIS {
   // With atomic RMW ops, perfectly balanced mark/unmark cycles must net to
   // zero, so the counter must return to its pre-test baseline.
   EXPECT_EQ(Metrics::GetStats().reclaimable_memory, baseline);
+}
+
+// The vector pointer slot at offsetData_ must be 8-byte aligned so its
+// read/write is atomic on weak memory models (ARM64); otherwise a concurrent
+// reader can observe a torn pointer and crash. maxM0_ = 2*M = 32 gives
+// size_links_level0_ = 32*4 + 4 = 132, which is not 8-aligned, so offsetData_
+// must be padded up to 136.
+TEST_F(VectorIndexTest, OffsetDataIsPointerAlignedOnCreate) {
+  hnswlib::L2Space l2_space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&l2_space, /*max_elements=*/16, kM,
+                                       kEFConstruction, /*random_seed=*/100,
+                                       /*allow_replace_deleted=*/false);
+  EXPECT_EQ(algo.offsetData_ % alignof(char*), 0u);
+  EXPECT_EQ(algo.size_data_per_element_ % alignof(char*), 0u);
+  EXPECT_GE(algo.offsetData_, algo.size_links_level0_);
+}
+
+namespace {
+// InputStream that yields a single pre-built chunk (the index header).
+class SingleChunkInputStream : public hnswlib::InputStream {
+ public:
+  explicit SingleChunkInputStream(std::string chunk)
+      : chunk_(std::move(chunk)) {}
+  absl::StatusOr<std::unique_ptr<std::string>> LoadChunk() override {
+    return std::make_unique<std::string>(chunk_);
+  }
+
+ private:
+  std::string chunk_;
+};
+}  // namespace
+
+// An index restored from an old snapshot stored the unpadded offset_data (132).
+// LoadIndex must recompute the aligned offset rather than trust the header,
+// otherwise the restored index keeps the misaligned layout and stays exposed to
+// the torn-pointer race. Builds an empty (curr_element_count=0) header with the
+// old offset_data and asserts the loaded index is aligned.
+TEST_F(VectorIndexTest, LoadRecomputesAlignedOffsetForOldSnapshot) {
+  hnswlib::L2Space l2_space{kDimensions};
+  const size_t unpadded_offset =
+      kM * 2 * sizeof(unsigned int) + sizeof(unsigned int);  // 132
+  ASSERT_NE(unpadded_offset % alignof(char*), 0u);
+
+  hnswlib::data_model::HNSWIndexHeader header;
+  header.set_offset_level_0(0);
+  header.set_max_elements(16);
+  header.set_curr_element_count(0);
+  header.set_serialize_size_data_per_element(
+      unpadded_offset + kDimensions * sizeof(float) + sizeof(size_t));
+  header.set_label_offset(unpadded_offset + sizeof(char*));
+  header.set_offset_data(unpadded_offset);
+  header.set_max_level(-1);
+  header.set_enterpoint_node(0);
+  header.set_max_m(kM);
+  header.set_max_m_0(kM * 2);
+  header.set_m(kM);
+  header.set_mult(1.0);
+  header.set_ef_construction(kEFConstruction);
+  std::string serialized;
+  ASSERT_TRUE(header.SerializeToString(&serialized));
+
+  hnswlib::HierarchicalNSW<float> algo(&l2_space);
+  SingleChunkInputStream input(serialized);
+  VMSDK_EXPECT_OK(
+      algo.LoadIndex(input, &l2_space, /*max_elements_i=*/16, nullptr));
+  EXPECT_EQ(algo.offsetData_ % alignof(char*), 0u);
+  EXPECT_EQ(algo.size_data_per_element_ % alignof(char*), 0u);
 }
 
 }  // namespace


### PR DESCRIPTION
Adds the two alignment regression tests from PR #1079 WITHOUT the fix, to demonstrate they fail on an unfixed tree.

- `OffsetDataIsPointerAlignedOnCreate`: asserts a constructed index has offsetData_ and the element stride 8-byte aligned.
- `LoadRecomputesAlignedOffsetForOldSnapshot`: feeds a header with the old unpadded offset_data=132 and asserts LoadIndex recomputes an aligned 136.

Base is clean upstream/main (no padding fix present), so both tests are expected to FAIL here. This is intentional - it confirms the tests actually guard the alignment invariant rather than just asserting current behavior.

Not for merge.